### PR TITLE
get rid of safari menu in iOS

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,8 +5,9 @@
     <!-- Microsoft -->
     <meta http-equiv="cleartype" content="on">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="initial-scale=1">
-
+    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    
     <title>Flow</title>
     <link rel="stylesheet" href="stylesheets/normalize.css">
     <link rel="shortcut icon" href="images/fluid.png" type="image/png">


### PR DESCRIPTION
hide the safari menu when launched from the springboard
